### PR TITLE
Fix issue where editor contents cannot be changed when databound to existing rules

### DIFF
--- a/src/RulesEngineEditor/Pages/RulesEngineEditorPage.razor.cs
+++ b/src/RulesEngineEditor/Pages/RulesEngineEditorPage.razor.cs
@@ -81,7 +81,7 @@ namespace RulesEngineEditor.Pages
     }
     protected override void OnParametersSet()
     {
-        if (Workflows != default)
+        if (Workflows != default && string.IsNullOrEmpty(WorkflowJSON))
         {
             var newJSON = JsonNormalizer.Normalize(JsonSerializer.Serialize(Workflows, jsonOptions));
             //var oldJSON = JsonNormalizer.Normalize(JsonSerializer.Serialize(JsonSerializer.Deserialize<List<Workflow>>(WorkflowJSON, jsonOptions)));


### PR DESCRIPTION
Reference issue at https://github.com/alexreich/RulesEngineEditor/issues/9

This fixes the bug where the editor reverts any changes made upon changing focus from an input and the New rule and Add rule buttons do not display the corresponding new rule edit components.