### PR TITLE
Added support for handling arrays when parsing JSON from a dynamic

### DIFF
--- a/src/RulesEngineEditor/Shared/JsonExtensions.cs
+++ b/src/RulesEngineEditor/Shared/JsonExtensions.cs
@@ -62,6 +62,21 @@ namespace RulesEngineEditor.Shared
                 using JsonDocument documentV = JsonDocument.ParseValue(ref reader);
                 return ReadObject(documentV.RootElement);
             }
+
+            if (reader.TokenType == JsonTokenType.StartArray)
+            {
+                var arrayItems = new List<dynamic>();
+                reader.Read();
+
+                while (reader.TokenType != JsonTokenType.EndArray)
+                {
+                    arrayItems.Add(Read(ref reader, typeToConvert, options));
+                    reader.Read();
+                }
+
+                return arrayItems;
+            }
+            
             // Use JsonElement as fallback.
             // Newtonsoft uses JArray or JObject.
             JsonDocument document = JsonDocument.ParseValue(ref reader);


### PR DESCRIPTION
Making this changes allows parsing arrays in JSON values to a dynamic properly.


This allows creating rules in the UI to parse array values, such as creating a `input.Contains(allowedValues)` expression with an input defined as `[ "test1", "test2", "test3" ]`
